### PR TITLE
copy license in root directory

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+## LICENSE ##
+
+The Open Food Facts phonegap mobile app is available under the MIT License (2008).
+
+The text of the MIT License is reproduced below.
+
+### The MIT License
+
+Copyright (c) 2012 Interesting Views SARL, Stéphane Gigandet, et. al.,
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.


### PR DESCRIPTION
The MIT license is in a subdirectory of the repository. To make it
obvious to anyone, this copy the license text in a new file LICENSE.md
at the root of the repository. Will make it obvious to anyone browsing
the repository on GitHub.

Fix #1 comment I made.
